### PR TITLE
Do not show markers for countries that are not supported by neither YouTube nor Twitter

### DIFF
--- a/trending_data/src/main/java/com/google/sps/servlets/Search.java
+++ b/trending_data/src/main/java/com/google/sps/servlets/Search.java
@@ -95,7 +95,7 @@ public class Search {
    * function that creates YTVid file from singleVideo object
    */
   private static ArrayList<YTVid> convertToYTVid(Iterator<Video> iteratorSearchResults) {
-    ArrayList result = new ArrayList<>();
+    ArrayList<YTVid> result = new ArrayList<>();
     while (iteratorSearchResults.hasNext()) {
       Video singleVideo = iteratorSearchResults.next();
 

--- a/trending_data/src/main/java/com/google/sps/servlets/TwitterSupportedCountriesServlet.java
+++ b/trending_data/src/main/java/com/google/sps/servlets/TwitterSupportedCountriesServlet.java
@@ -1,0 +1,58 @@
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import twitter4j.Location;
+import twitter4j.ResponseList;
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+
+@WebServlet("/twitter-supported-countries")
+public class TwitterSupportedCountriesServlet extends HttpServlet {
+  /** This variable is empty upon class instantion */
+  HashSet<String> twitterSupportedCountries = new HashSet<>();
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    try {
+      if (twitterSupportedCountries.isEmpty()) {
+        /**
+         * if this is the first request, fetch the supported countries this will only occur once,
+         * right after the servlet is instantiated
+         */
+        Twitter twitter = new TwitterFactory().getInstance();
+        twitterSupportedCountries = convertToSetOfCountryCodes(twitter.getAvailableTrends());
+      }
+      response.setContentType("application/json;");
+      response.getWriter().println(new Gson().toJson(twitterSupportedCountries));
+    } catch (NumberFormatException nfException) {
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      System.out.println(nfException.getMessage());
+    } catch (TwitterException twitterException) {
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      System.out.println(twitterException.getMessage());
+    }
+  }
+
+  /**
+   * Create a set of alpha 2 codes which correspond to a list of Twitter Locations. Does not allow
+   * duplicates.
+   *
+   * @see twitter4j.Location
+   */
+  private HashSet<String> convertToSetOfCountryCodes(ResponseList<Location> locations) {
+    HashSet<String> countryCodes = new HashSet<>();
+    Iterator<Location> iterator = locations.iterator();
+
+    while (iterator.hasNext()) {
+      Location currentLocation = iterator.next();
+      countryCodes.add(currentLocation.getCountryCode());
+    }
+    return countryCodes;
+  }
+}

--- a/trending_data/src/main/java/com/google/sps/servlets/YTSupportedCountriesSearch.java
+++ b/trending_data/src/main/java/com/google/sps/servlets/YTSupportedCountriesSearch.java
@@ -71,13 +71,13 @@ public class YTSupportedCountriesSearch {
     return new ArrayList<String>();
   }
 
-  /*
-   * Creates a list of Alpha-2 codes by getting the id of each region in the
-   * list of I18nRegion objects
+  /**
+   * Creates a list of Alpha-2 codes by getting the id of each region in the list of I18nRegion
+   * objects
    */
   private static ArrayList<String> convertToListOfCountryCodes(
       Iterator<I18nRegion> iteratorSearchResults) {
-    ArrayList result = new ArrayList<>();
+    ArrayList<String> result = new ArrayList<>();
     while (iteratorSearchResults.hasNext()) {
       I18nRegion region = iteratorSearchResults.next();
       String id = region.getId(); // this is the country code of the region (Alpha-2 code)

--- a/trending_data/src/main/webapp/index.html
+++ b/trending_data/src/main/webapp/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Simple Map</title>
+    <title>Trend Map</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="./map_style.css">
     <script src="read_maps_key.js"></script>
     <script src="./script.js"></script>
     <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
     <script src="https://unpkg.com/@google/markerclustererplus@4.0.1/dist/markerclustererplus.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="./map_style.css" />
   </head>
   <body>
     <div id="map"></div>


### PR DESCRIPTION
### In script.js

* fetch countries supported by YouTube and those supported by Twitter
* compute union between these two sets of countries
* when a marker is added for a certain country
  - display marker only if that country is part of the union

### Twitter servlet to get supported countries

* return set of country codes for countries supported by twitter
  - does not allow duplicates
* API call will only be made once upon servlet instantiation

### Problem

* fetching the supported countries has to be a synchronous operation because the markers can only be added to the map once we know which countries we want to have markers for
* therefore, we have to wait for the supported countries to be fetched which produces a very short delay when the page is loaded
* **solutions**:
  - show some loading animation
  - hardcode the unsupported countries instead
  - no change because the delay is barely perceivable